### PR TITLE
Límite de nacimientos por hospital a 200

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,6 +332,14 @@ function visualizeThisDate(datestring){
 
 	var date = datestring.split("-");
 	dataxfecha = data[date[0]][date[1]];
+	var delay = 500; //1/2 segundo
+	for (var property in dataxfecha) {
+	    if (dataxfecha.hasOwnProperty(property)) {
+	        if (dataxfecha[property]['nacimientos'] >= 200)
+	        	dataxfecha[property]['nacimientos'] = 200;
+	    }
+	}
+
 
 	hospitalesids = Object.keys(dataxfecha);
 	nodes = {};
@@ -351,21 +359,39 @@ function visualizeThisDate(datestring){
 	 //si no tiene defunciones ni nacimientos sal.
 	 if(nodes[hid]["children"].length==0){ return;}
 
+    debugger;
+	bubbleHospitals[hid] = 
+		posicioneshospitales[hid]
+		.selectAll("circle."+hid)
+		.data(
+			bubble.nodes(classes(nodes[hid]))
+		);
 
-	bubbleHospitals[hid] = posicioneshospitales[hid].selectAll("circle."+hid)
-	.data(bubble.nodes(classes(nodes[hid])));
+	bubbleHospitals[hid]
+		.enter()
+		.append("circle")
+			.attr("class",hid)
+			.attr("id",function(d){return d.estado;})
+			.attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; })
+			//.style("fill","white")
+			.style("opacity", 0.0)
+			.attr("r",bubble_radius);
 
-	bubbleHospitals[hid].enter().append("circle").attr("class",hid).attr("id",function(d){return d.estado;})
-	.attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; })
-	.style("fill","white")
-	.attr("r",bubble_radius);
+	bubbleHospitals[hid]
+		.attr("r", bubble_radius)
+		.transition()
+      	.duration(delay)
+      	.style("fill",function(d,i){ return d.estado=="vivo" ?  colorvivos(i):colorsmuertos(i);})
+      	.style("opacity",1.0)
+      	.attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; })
 
-	bubbleHospitals[hid].attr("r",bubble_radius).transition()
-      .duration(300)
-      .style("fill",function(d,i){return d.estado=="vivo" ?  colorvivos(i):colorsmuertos(i);})
-      .attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; })
-
-	bubbleHospitals[hid].exit().transition().duration(300).attr("r",0).remove();
+	bubbleHospitals[hid]
+		.exit()
+		.transition()
+		.duration(delay)
+		.style("opacity",0.0)
+		//.attr("r",0)
+		.remove();
 
 	
 	});


### PR DESCRIPTION
Se limitó el número de puntos verdes (nacimientos) a 200 por hospital,
anteriormente se pintaban hasta 1.7k puntos en un sólo hospital.

Se aumentó el delay de las transiciones a 1/2 segundo y se agregaron
cambios de opacidad, en vez del cambio de radio para aparecer/desaparecer, en los círculos.
